### PR TITLE
chore: rename req to breq in developer hub

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,7 +366,7 @@ bai chat start "Summarize last quarter's sales from SAP"</pre>
     <div class="grid">
       <a class="card" href="https://github.com/bluefunda/bluerequests">
         <p class="card-title">bluerequests <span class="arrow">→</span></p>
-        <p class="card-desc">CLI for BlueRequests change and release management (<code>req</code> binary) — TUI dashboard, CRs, events, approvals.</p>
+        <p class="card-desc">CLI for BlueRequests change and release management (<code>breq</code> binary) — TUI dashboard, CRs, events, approvals.</p>
         <div class="card-meta"><span class="tag">Go</span><span class="tag">Apache-2.0</span></div>
       </a>
     </div>
@@ -375,14 +375,14 @@ bai chat start "Summarize last quarter's sales from SAP"</pre>
       <h3>Quick Install</h3>
 <pre><span class="comment"># Homebrew (macOS/Linux)</span>
 brew tap bluefunda/tap
-brew install --cask req</pre>
+brew install --cask breq</pre>
 <pre><span class="comment"># One-line installer</span>
 curl -fsSL https://raw.githubusercontent.com/bluefunda/bluerequests/main/install.sh | sh</pre>
 <pre><span class="comment"># Or install from source</span>
-go install github.com/bluefunda/bluerequests/cmd/req@latest</pre>
+go install github.com/bluefunda/bluerequests/cmd/breq@latest</pre>
 <pre><span class="comment"># Authenticate and open the TUI dashboard</span>
-req login
-req</pre>
+breq login
+breq</pre>
     </div>
   </section>
 


### PR DESCRIPTION
Follows bluerequests/31 — renames binary from req to breq to avoid Homebrew conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)